### PR TITLE
ENH: add a decorator for use with generic_filter1d

### DIFF
--- a/llc/__init__.py
+++ b/llc/__init__.py
@@ -1,3 +1,3 @@
-from .ndimage import jit_filter_function
+from .ndimage import jit_filter_function, jit_filter1d_function
 
 __version__ = '0.2.0-dev'

--- a/llc/ndimage.py
+++ b/llc/ndimage.py
@@ -3,11 +3,27 @@ from numba import cfunc, carray
 from numba.types import intc, CPointer, float64, intp, voidptr
 from scipy import LowLevelCallable
 
+
 def jit_filter_function(filter_function):
+    """Decorator for use with scipy.ndimage.generic_filter."""
     jitted_function = numba.jit(filter_function, nopython=True)
+
     @cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
     def wrapped(values_ptr, len_values, result, data):
         values = carray(values_ptr, (len_values,), dtype=float64)
         result[0] = jitted_function(values)
+        return 1
+    return LowLevelCallable(wrapped.ctypes)
+
+
+def jit_filter1d_function(filter_function):
+    """Decorator for use with scipy.ndimage.generic_filter1d."""
+    jitted_function = numba.jit(filter_function, nopython=True)
+
+    @cfunc(intc(CPointer(float64), intp, CPointer(float64), intp, voidptr))
+    def wrapped(in_values_ptr, len_in, out_values_ptr, len_out, data):
+        in_values = carray(in_values_ptr, (len_in,), dtype=float64)
+        out_values = carray(out_values_ptr, (len_out,), dtype=float64)
+        jitted_function(in_values, out_values)
         return 1
     return LowLevelCallable(wrapped.ctypes)


### PR DESCRIPTION
Hi Juan, 
Following the example from your blog post, I have added a decorator for use with `ndimage.generic_filter1d`.  It has a different signature than the existing one for `ndimage.generic_filter` because it operates on a whole line at a time rather than pixel by pixel.

Below is simple example verifying the proper behavior.  Performance on this example is worse than the equivalent `numpy.diff` call, but better than the case without the `jit_filter1d_function` decorator.  The use of an undecorated function has less overhead in this case than for the `generic_filter` example in your blog post since the function gets called for each line rather than for each pixel.  

```python
import numpy as np
from numpy.testing import assert_
from matplotlib import pyplot as plt
from scipy import ndimage as ndi
from scipy.misc import ascent
from llc import jit_filter1d_function
img = ascent().astype(np.float64)


@jit_filter1d_function
def forward_diff(iline, oline):
    """Forward finite difference."""
    oline[...] = iline[1:] - iline[:-1]


diff0 = ndi.generic_filter1d(img, forward_diff, filter_size=2, axis=0)
diff1 = ndi.generic_filter1d(img, forward_diff, filter_size=2, axis=1)

# verify result is the same as numpy.diff
# (excluding boundary pixels dropped by numpy.diff)
assert_(np.max(diff0[1:, :] - np.diff(img, n=1, axis=0)) == 0)
assert_(np.max(diff1[:, 1:] - np.diff(img, n=1, axis=1)) == 0)

# show the result
fig, axes = plt.subplots(1, 3)
axes[0].imshow(img, cmap=plt.cm.gray)
axes[0].set_title('original')
axes[1].imshow(diff0, cmap=plt.cm.gray)
axes[1].set_title('filtered: axis 0')
axes[2].imshow(diff1, cmap=plt.cm.gray)
axes[2].set_title('filtered: axis 1')
for ax in axes:
    ax.set_axis_off()


```