### PR TITLE
BLD: fix setup.py issue that prevents install with pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ LICENSE             = 'BSD 3-clause'
 DOWNLOAD_URL        = 'https://github.com/jni/llc-tools'
 VERSION             = '0.2.0-dev'
 PYTHON_VERSION      = (3, 6)
-INST_DEPENDENCIES   = {} 
+INST_DEPENDENCIES   = []
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
install_requires needs to be a list.  For version 0.1.1 on PyPI,
`pip install llc` gives:

    Complete output from command python setup.py egg_info:
    error in llc setup command: 'install_requires' must be a string or
    list of strings containing valid project/version requirement
    specifiers; Unordered types are not allowed