### PR TITLE
Fix Numba import for 0.50.0

### DIFF
--- a/llc/ndimage.py
+++ b/llc/ndimage.py
@@ -1,6 +1,6 @@
 import numba
 from numba import cfunc, carray
-from numba.types import intc, CPointer, float64, intp, voidptr
+from numba.core.types import intc, CPointer, float64, intp, voidptr
 from scipy import LowLevelCallable
 
 


### PR DESCRIPTION
Numba is moving a number of functions from numba.types to numba.core.types. This update removes a warning with 0.59, and maintains compatibility with 0.50 and later