### PR TITLE
update for windows

### DIFF
--- a/llc/ndimage.py
+++ b/llc/ndimage.py
@@ -1,3 +1,4 @@
+import sys
 import numba
 from numba import cfunc, carray
 from numba.core.types import intc, CPointer, float64, intp, voidptr
@@ -13,7 +14,11 @@ def jit_filter_function(filter_function):
         values = carray(values_ptr, (len_values,), dtype=float64)
         result[0] = jitted_function(values)
         return 1
-    return LowLevelCallable(wrapped.ctypes)
+
+    sig = None
+    if sys.platform == "win32":
+        sig = "int (double *, npy_intp, double *, void *)"
+    return LowLevelCallable(wrapped.ctypes, signature=sig)
 
 
 def jit_filter1d_function(filter_function):
@@ -26,7 +31,11 @@ def jit_filter1d_function(filter_function):
         out_values = carray(out_values_ptr, (len_out,), dtype=float64)
         jitted_function(in_values, out_values)
         return 1
-    return LowLevelCallable(wrapped.ctypes)
+
+    sig = None
+    if sys.platform == "win32":
+        sig = "int (double *, npy_intp, double *, npy_intp, void *)"
+    return LowLevelCallable(wrapped.ctypes, signature=sig)
 
 
 def jit_geometric_function(geometric_function):
@@ -38,4 +47,9 @@ def jit_geometric_function(geometric_function):
         input_coords = carray(input_ptr, (output_rank,), dtype=float64)
         jitted_function(output_coords, input_coords)
         return 1
-    return LowLevelCallable(wrapped.ctypes)
+
+    # needs to be tested
+    # sig = None
+    # if sys.platform == "win32":
+    #     sig = "int (double *, double *, int, int, void *)"
+    return LowLevelCallable(wrapped.ctypes, signature=sig)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,15 +1,14 @@
 name: llc-test
 channels:
-- conda-forge
+  - conda-forge
 dependencies:
-- python>=3.6*
-- setuptools>=19.6*
-- numba>=0.29
-- numpy>=1.12*
-- numpydoc>=0.5*
-- scipy>=0.19*
-- pytest>=3*
-- coverage>=4.0
-- pytest-cov>=2.2
-- pip:
-  - hypothesis>=3.6
+  - python>=3.8*
+  - setuptools>=19.6*
+  - numba>=0.5
+  - numpy>=1.18*
+  - numpydoc>=0.5*
+  - scipy>=1.6*
+  - pytest>=6*
+  - coverage>=4.0
+  - pytest-cov>=2.2
+  - hypothesis>=5*

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,41 @@
+import pytest
+from hypothesis import given, settings
+import hypothesis.strategies as hs
+
+from scipy.ndimage import generic_filter, generic_filter1d, geometric_transform
+import numpy as np
+from llc import jit_filter_function, jit_filter1d_function
+
+
+def fnc_zero(values):
+    return values[0]*0
+
+
+def fnc_zero_inplace(iline, oline):
+    oline[...] = iline[0]*0.0
+
+
+@given(hs.lists(hs.integers(5, 15), min_size=1, max_size=3),
+       hs.integers(1, 5)
+)
+@settings(deadline=10000)
+def test_generic_filter(arr_dim, fsize):
+    arr = np.random.random(arr_dim)
+    footprint = [d//fsize for d in arr_dim]
+    # just make sure it runs
+    filtered = generic_filter(arr, jit_filter_function(fnc_zero), size=footprint)
+    assert np.allclose(filtered, 0.0)
+
+
+@given(hs.lists(hs.integers(5, 15), min_size=2, max_size=2),
+       hs.integers(1, 5)
+)
+@settings(deadline=10000)
+def test_generic_filter1d(arr_dim, fsize):
+    arr = np.random.random(arr_dim)
+    axis = np.random.randint(0, arr.ndim-1)
+    fsize = arr_dim[axis]//fsize
+    # just make sure it runs
+    filtered = generic_filter1d(arr, jit_filter1d_function(fnc_zero_inplace), fsize, axis=axis)
+    assert np.allclose(filtered, 0.0)
+


### PR DESCRIPTION
Fix windows signature bug with platform specific call.
Added tests for generic_filter and generic_filter1d

Hiya,

I had a go at improving these for windows. I've added a platform test because I didn't want to affect the behaviour on Linux where the code is working. I also added a few simple tests to make sure the code runs using `pytest`. I haven't used geometric_filter before so I've left that for someone who know better what they are doing.